### PR TITLE
Remove no-op BZip2Config.work_factor parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ config = hdiffpatch.LzmaConfig.minimal_memory()
 Fine-grained control over bzip2 compression:
 
 ```python
-config = hdiffpatch.BZip2Config(level=9, work_factor=30)
+config = hdiffpatch.BZip2Config(level=9)
 
 # Preset configurations
 config = hdiffpatch.BZip2Config.fast()
@@ -251,7 +251,6 @@ config = hdiffpatch.BZip2Config.minimal_memory()
 **Parameters:**
 
 * `level` (1-9): Compression level
-* `work_factor` (0-250): Work factor for worst-case scenarios
 
 #### TampConfig
 

--- a/hdiffpatch/_bzip2_config.py
+++ b/hdiffpatch/_bzip2_config.py
@@ -1,7 +1,5 @@
 """BZip2Config class for configuring bzip2 compression parameters."""
 
-from typing import Union
-
 import attrs
 
 from ._base_config import BaseConfig
@@ -11,33 +9,25 @@ from ._base_config import BaseConfig
 class BZip2Config(BaseConfig):
     """Configuration for bzip2 compression parameters.
 
-    This class allows fine-grained control over bzip2 compression behavior,
-    including compression level and work factor for controlling compression
-    speed and memory usage.
+    This class allows control over bzip2 compression behavior via the
+    compression level, which trades speed for compression ratio and
+    memory usage.
 
     Parameters
     ----------
     level : int, default=9
         Compression level (1-9). Higher values give better
         compression but are slower. 1 = fastest, 9 = best compression.
-    work_factor : int, default=30
-        Work factor (0-250). Controls how the compression algorithm
-        behaves when dealing with worst-case scenarios. 0 = use default,
-        higher values use more time but may achieve better compression.
 
     Examples
     --------
-    Fast compression with minimal memory usage
+    Fast compression
 
-    >>> config = BZip2Config(level=1, work_factor=0)
+    >>> config = BZip2Config(level=1)
 
-    Best compression with default work factor
+    Best compression
 
     >>> config = BZip2Config(level=9)
-
-    Balanced compression with increased work factor
-
-    >>> config = BZip2Config(level=6, work_factor=100)
     """
 
     level: int = attrs.field(
@@ -46,14 +36,6 @@ class BZip2Config(BaseConfig):
             attrs.validators.instance_of(int),
             attrs.validators.ge(1),
             attrs.validators.le(9),
-        ),
-    )
-    work_factor: int = attrs.field(
-        default=30,
-        validator=attrs.validators.and_(
-            attrs.validators.instance_of(int),
-            attrs.validators.ge(0),
-            attrs.validators.le(250),
         ),
     )
 
@@ -66,7 +48,7 @@ class BZip2Config(BaseConfig):
         BZip2Config
             Configuration optimized for speed
         """
-        return cls(level=1, work_factor=0)
+        return cls(level=1)
 
     @classmethod
     def balanced(cls) -> "BZip2Config":
@@ -77,7 +59,7 @@ class BZip2Config(BaseConfig):
         BZip2Config
             Configuration with balanced speed/compression tradeoff
         """
-        return cls(level=6, work_factor=30)
+        return cls(level=6)
 
     @classmethod
     def best_compression(cls) -> "BZip2Config":
@@ -88,7 +70,7 @@ class BZip2Config(BaseConfig):
         BZip2Config
             Configuration optimized for best compression
         """
-        return cls(level=9, work_factor=100)
+        return cls(level=9)
 
     @classmethod
     def minimal_memory(cls) -> "BZip2Config":
@@ -99,4 +81,4 @@ class BZip2Config(BaseConfig):
         BZip2Config
             Configuration with minimal memory usage
         """
-        return cls(level=1, work_factor=0)
+        return cls(level=1)

--- a/tests/test_bzip2_config.py
+++ b/tests/test_bzip2_config.py
@@ -13,13 +13,16 @@ class TestBZip2ConfigClass:
         """Test default BZip2Config construction."""
         config = BZip2Config()
         assert config.level == 9
-        assert config.work_factor == 30
 
     def test_custom_construction(self):
         """Test BZip2Config construction with custom parameters."""
-        config = BZip2Config(level=6, work_factor=100)
+        config = BZip2Config(level=6)
         assert config.level == 6
-        assert config.work_factor == 100
+
+    def test_work_factor_removed(self):
+        """Test that the former no-op work_factor parameter is rejected."""
+        with pytest.raises(TypeError):
+            BZip2Config(work_factor=30)  # type: ignore[call-arg]
 
 
 class TestBZip2ConfigValidation:
@@ -43,23 +46,6 @@ class TestBZip2ConfigValidation:
         with pytest.raises(TypeError, match="'level' must be <class 'int'>"):
             BZip2Config(level=level)  # type: ignore[arg-type]
 
-    @pytest.mark.parametrize("factor", [0, 30, 100, 250])
-    def test_work_factor_valid_values(self, factor):
-        """Test work factor accepts valid values."""
-        config = BZip2Config(work_factor=factor)
-        assert config.work_factor == factor
-
-    @pytest.mark.parametrize("factor", [-1, 251])
-    def test_work_factor_invalid_range(self, factor):
-        """Test work factor rejects out-of-range values."""
-        with pytest.raises(ValueError, match="'work_factor' must be"):
-            BZip2Config(work_factor=factor)
-
-    def test_work_factor_invalid_type(self):
-        """Test work factor rejects invalid types."""
-        with pytest.raises(TypeError, match="'work_factor' must be <class 'int'>"):
-            BZip2Config(work_factor="30")  # type: ignore[arg-type]
-
 
 class TestBZip2ConfigClassmethods:
     """Test BZip2Config classmethod constructors."""
@@ -67,34 +53,10 @@ class TestBZip2ConfigClassmethods:
     @pytest.mark.parametrize(
         "method_name,expected_attrs",
         [
-            (
-                "fast",
-                {
-                    "level": 1,
-                    "work_factor": 0,
-                },
-            ),
-            (
-                "balanced",
-                {
-                    "level": 6,
-                    "work_factor": 30,
-                },
-            ),
-            (
-                "best_compression",
-                {
-                    "level": 9,
-                    "work_factor": 100,
-                },
-            ),
-            (
-                "minimal_memory",
-                {
-                    "level": 1,
-                    "work_factor": 0,
-                },
-            ),
+            ("fast", {"level": 1}),
+            ("balanced", {"level": 6}),
+            ("best_compression", {"level": 9}),
+            ("minimal_memory", {"level": 1}),
         ],
     )
     def test_classmethod_configs(self, method_name, expected_attrs):
@@ -109,9 +71,9 @@ class TestBZip2ConfigMethods:
 
     def test_hashability(self):
         """Test that BZip2Config objects are hashable."""
-        config1 = BZip2Config(level=6, work_factor=50)
-        config2 = BZip2Config(level=6, work_factor=50)
-        config3 = BZip2Config(level=9, work_factor=50)
+        config1 = BZip2Config(level=6)
+        config2 = BZip2Config(level=6)
+        config3 = BZip2Config(level=9)
 
         # Test that equal objects have same hash
         assert hash(config1) == hash(config2)
@@ -196,28 +158,13 @@ class TestBZip2ConfigIntegration:
         result = hdiffpatch.apply(highly_compressible_data["old"], diff_data)
         assert result == highly_compressible_data["new"]
 
-    @pytest.mark.parametrize("work_factor", [0, 30, 100])
-    def test_diff_work_factors(self, binary_data, work_factor):
-        """Test diff() with different work factors."""
-        config = BZip2Config(work_factor=work_factor)
-
-        # Test that diff accepts different work factors
-        diff_data = hdiffpatch.diff(binary_data["old"], binary_data["new"], compression=config)
-
-        assert isinstance(diff_data, bytes)
-        assert len(diff_data) > 0
-
-        # Test round-trip
-        result = hdiffpatch.apply(binary_data["old"], diff_data)
-        assert result == binary_data["new"]
-
 
 class TestBZip2ConfigRoundTrip:
     """Test round-trip functionality with BZip2Config."""
 
     def test_round_trip_with_config(self, simple_text_data):
         """Test complete round-trip with BZip2Config."""
-        config = BZip2Config(level=6, work_factor=50)
+        config = BZip2Config(level=6)
 
         # Test complete round-trip with BZip2Config
         diff_data = hdiffpatch.diff(simple_text_data["old"], simple_text_data["new"], compression=config)


### PR DESCRIPTION
## Summary

`BZip2Config.work_factor` was documented, validated, and tested — but never had any effect. The underlying HDiffPatch bz2 plugin struct (`TCompressPlugin_bz2` in `compress_plugin_demo.h`) only exposes `compress_level`; there is no work-factor field to pass the value into. Verified empirically: `work_factor=1` and `work_factor=250` produce byte-identical diffs.

This removes the parameter rather than silently accepting it, so users tuning it get an immediate `TypeError` instead of a false sense of control.

## Changes

- Remove `work_factor` field from `BZip2Config` and from all preset classmethods.
- Update tests: drop work-factor validation/integration tests, add a regression test asserting the parameter is now rejected.
- Update README's BZip2Config section.

## Notes

Technically an API-surface change: code passing `work_factor=` will now raise `TypeError`. Since the parameter never did anything, removal seemed more honest than a deprecation cycle — happy to switch to a `DeprecationWarning` shim if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
