### PR TITLE
Fix error handling and integer-safety issues in Cython extension

### DIFF
--- a/hdiffpatch/_c_extension.pyx
+++ b/hdiffpatch/_c_extension.pyx
@@ -605,9 +605,12 @@ cdef hpatch_StreamPos_t calculate_new_data_size(const unsigned char* diff_ptr, c
 
         # After processing all covers, the total new data size is:
         # newPosBack + remaining newDataDiff data
-        remaining_newDataDiff = newDataDiffSize - newDataDiff_used
-        if remaining_newDataDiff < 0:
+        # (operands are unsigned; guard before subtracting so a malformed diff
+        # can't wrap around to a huge value)
+        if newDataDiff_used > newDataDiffSize:
             remaining_newDataDiff = 0
+        else:
+            remaining_newDataDiff = newDataDiffSize - newDataDiff_used
 
         total_size = newPosBack + remaining_newDataDiff
 
@@ -685,7 +688,12 @@ cdef hpatch_BOOL _vector_output_write(const hpatch_TStreamOutput* stream,
     """C callback function for writing to vector output stream."""
     cdef VectorOutputStream self_obj = <VectorOutputStream>stream.streamImport
     cdef size_t data_size = data_end - data
-    cdef size_t required_size = writeToPos + data_size
+    cdef hpatch_StreamPos_t required_size_64 = writeToPos + data_size
+    # Stream positions are 64-bit; reject writes beyond what size_t can
+    # address (only reachable on 32-bit builds).
+    if required_size_64 != <hpatch_StreamPos_t><size_t>required_size_64:
+        return 0  # hpatch_FALSE
+    cdef size_t required_size = <size_t>required_size_64
 
     try:
         # Resize vector if necessary
@@ -764,7 +772,7 @@ cdef CompressionPlugin _resolve_compression_to_plugin(compression: Union[Compres
         # String-based compression - normalize and validate
         compression_str = str(compression).lower()
         if compression_str not in _valid_compression_types:
-            raise ValueError(f"Invalid compression type: {compression_str}. Valid options: {', '.join(_valid_compression_types)}")
+            raise ValueError(f"Invalid compression type: {compression_str}. Valid options: {', '.join(sorted(_valid_compression_types))}")
 
         if compression_str == COMPRESSION_NONE:
             return None
@@ -837,12 +845,10 @@ def diff(
     if validate:
         try:
             result_data = apply(old_data, diff_bytes)
-            if result_data != new_data:
-                raise HDiffPatchError("Roundtrip validation failed: applying the diff to old_data does not produce new_data")
         except Exception as e:
-            if isinstance(e, HDiffPatchError) and "Roundtrip validation failed" in str(e):
-                raise
             raise HDiffPatchError(f"Roundtrip validation failed: {str(e)}") from e
+        if result_data != new_data:
+            raise HDiffPatchError("Roundtrip validation failed: applying the diff to old_data does not produce new_data")
 
     return diff_bytes
 
@@ -936,6 +942,10 @@ def apply(
         if new_ptr != NULL:
             free(new_ptr)
         return result_bytes
+    except (HDiffPatchError, MemoryError):
+        if new_ptr != NULL:
+            free(new_ptr)
+        raise
     except Exception as e:
         if new_ptr != NULL:
             free(new_ptr)
@@ -1024,6 +1034,8 @@ def recompress(
                 "diffs even when no compression is applied, which are supported by this function."
             )
 
+    except HDiffPatchError:
+        raise
     except Exception as e:
         raise HDiffPatchError(f"Failed to detect diff format: {str(e)}") from e
 
@@ -1064,5 +1076,7 @@ def recompress(
         result_vector = output_stream.get_vector()
         return PyBytes_FromStringAndSize(<char*>result_vector.data(), result_size)
 
+    except HDiffPatchError:
+        raise
     except Exception as e:
         raise HDiffPatchError(f"Recompression failed: {str(e)}") from e

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -17,8 +17,22 @@ def test_diff_error_propagation():
 
 
 def test_patch_error_propagation():
-    """Test that PatchError is properly raised and contains useful information."""
+    """Test that patch errors are properly raised and contain useful information."""
     with pytest.raises(hdiffpatch.HDiffPatchError) as exc_info:
         hdiffpatch.apply(b"test", b"invalid_diff_data")
 
-    assert "patch" in str(exc_info.value).lower()
+    assert "diff" in str(exc_info.value).lower()
+
+
+def test_apply_error_not_double_wrapped():
+    """Test that internal HDiffPatchErrors are not re-wrapped with a second prefix."""
+    with pytest.raises(hdiffpatch.HDiffPatchError) as exc_info:
+        hdiffpatch.apply(b"test", b"invalid_diff_data")
+
+    assert str(exc_info.value).count("Patch application failed") <= 1
+
+
+def test_invalid_compression_error_message_sorted():
+    """Test that the invalid-compression error lists options in stable sorted order."""
+    with pytest.raises(ValueError, match="Valid options: bzip2, lzma, lzma2, none, tamp, zlib, zstd"):
+        hdiffpatch.diff(b"old", b"new", compression="bogus")  # pyright: ignore[reportArgumentType]

--- a/tests/test_recompress.py
+++ b/tests/test_recompress.py
@@ -254,7 +254,7 @@ class TestRecompressEdgeCases:
         """Test recompress with corrupted diff data."""
         corrupted_data = b"this is not a valid diff"
 
-        with pytest.raises(hdiffpatch.HDiffPatchError, match="Failed to detect diff format"):
+        with pytest.raises(hdiffpatch.HDiffPatchError, match="Cannot recompress legacy uncompressed diff format"):
             hdiffpatch.recompress(corrupted_data, compression=hdiffpatch.COMPRESSION_ZLIB)
 
     def test_recompress_empty_data(self):


### PR DESCRIPTION
## Summary

Fixes several error-handling and integer-safety issues in `_c_extension.pyx` found during a repo review.

## Changes

- **Dead overflow guard**: in `calculate_new_data_size`, `remaining_newDataDiff < 0` could never be true — both operands are unsigned `hpatch_StreamPos_t`, so a malformed diff where `newDataDiff_used > newDataDiffSize` wrapped around to a huge value instead of triggering the guard. Now checks before subtracting.
- **No more double-wrapping**: `apply()` and `recompress()` re-raise internal `HDiffPatchError`s unchanged instead of nesting them inside "Patch application failed: …" / "Failed to detect diff format: …" prefixes. Notably, corrupted input to `recompress()` now surfaces the intended, informative "Cannot recompress legacy uncompressed diff format…" message instead of having it mangled by the detection wrapper.
- **`MemoryError` propagates** from `apply()` as its docstring always claimed; previously the blanket `except Exception` converted it to `HDiffPatchError`.
- **Cleaner roundtrip validation** in `diff()`: the `isinstance` + substring-matching re-raise hack is replaced by moving the comparison out of the `try`.
- **32-bit safety**: `_vector_output_write` computed `writeToPos + data_size` in `size_t`, which truncates 64-bit stream positions on 32-bit builds; it now computes in 64 bits and rejects writes that don't fit `size_t`.
- **Stable error message**: the invalid-compression `ValueError` now lists valid options sorted instead of in arbitrary `set` iteration order.

## Tests

- New: regression tests for no-double-wrapping and the sorted error message.
- Updated: two tests that asserted on the old wrapped message text.
- Full suite: 509 passed; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
