### PR TITLE
Fix fresh-clone bootstrap: auto-cythonize in setup.py

### DIFF
--- a/cythonize.py
+++ b/cythonize.py
@@ -56,9 +56,6 @@ def generate_c_extension():
         },
     )
 
-    print("SUCCESS: Cython files compiled to C++")
-    print("Generated: hdiffpatch/_c_extension.cpp")
-
 
 if __name__ == "__main__":
     generate_c_extension()

--- a/rebuild.py
+++ b/rebuild.py
@@ -7,39 +7,28 @@ from pathlib import Path
 
 
 def rebuild_extensions():
-    """Force rebuild of Cython extensions."""
-    print("Regenerating C++ from Cython...")
+    """Force rebuild of the hdiffpatch package.
 
-    # First, regenerate C++ files from Cython
-    cythonize_result = subprocess.run(  # noqa: S603
-        [sys.executable, "cythonize.py"],
+    setup.py regenerates C++ from Cython automatically whenever
+    _c_extension.pyx is newer than the generated _c_extension.cpp.
+    """
+    print("Rebuilding hdiffpatch...")
+
+    result = subprocess.run(  # noqa: S603
+        ["uv", "sync", "--reinstall-package", "hdiffpatch"],  # noqa: S607
         cwd=Path(__file__).parent,
     )
-
-    if cythonize_result.returncode != 0:
-        print("❌ Failed to regenerate C++ files")
+    if result.returncode != 0:
+        print("ERROR: Failed to rebuild extensions")
         sys.exit(1)
 
-    print("Rebuilding Cython extensions...")
-
-    # Use pip to force rebuild the package
-    result = subprocess.run(  # noqa: S603
-        [sys.executable, "-m", "pip", "install", "-e", ".", "--force-reinstall", "--no-deps"], cwd=Path(__file__).parent
-    )
-
-    if result.returncode == 0:
-        print("✅ Extensions rebuilt successfully!")
-        # Test the import
-        try:
-            import hdiffpatch
-
-            print("✅ Import test passed!")
-        except ImportError as e:
-            print(f"❌ Import test failed: {e}")
-            sys.exit(1)
-    else:
-        print("❌ Failed to rebuild extensions")
+    try:
+        import hdiffpatch  # noqa: F401
+    except ImportError as e:
+        print(f"ERROR: Import test failed: {e}")
         sys.exit(1)
+
+    print("SUCCESS: Extensions rebuilt.")
 
 
 if __name__ == "__main__":

--- a/rebuild.py
+++ b/rebuild.py
@@ -12,8 +12,6 @@ def rebuild_extensions():
     setup.py regenerates C++ from Cython automatically whenever
     _c_extension.pyx is newer than the generated _c_extension.cpp.
     """
-    print("Rebuilding hdiffpatch...")
-
     result = subprocess.run(  # noqa: S603
         ["uv", "sync", "--reinstall-package", "hdiffpatch"],  # noqa: S607
         cwd=Path(__file__).parent,

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,29 @@
 
 import os
 import platform
+import sys
 from pathlib import Path
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
+
+
+def ensure_cythonized():
+    """Generate _c_extension.cpp from the .pyx source when missing or stale."""
+    root = Path(__file__).parent
+    pyx = root / "hdiffpatch" / "_c_extension.pyx"
+    cpp = root / "hdiffpatch" / "_c_extension.cpp"
+    if not pyx.exists():  # building from a tree that only ships the .cpp
+        return
+    if cpp.exists() and cpp.stat().st_mtime >= pyx.stat().st_mtime:
+        return
+    sys.path.insert(0, str(root))
+    from cythonize import generate_c_extension
+
+    generate_c_extension()
+
+
+ensure_cythonized()
 
 
 class CustomBuildExt(build_ext):


### PR DESCRIPTION
## Summary

Fixes the fresh-clone bootstrap: `uv sync` previously failed on a clean checkout because building the package requires the generated `_c_extension.cpp`, which only `cythonize.py` could produce — and running that needed a venv that `uv sync` was still trying to create. CI worked around this with a hand-built pip venv before every build (removable once this merges; see the CI overhaul PR).

## Changes

- **`setup.py` auto-cythonizes**: regenerates `_c_extension.cpp` whenever it is missing or older than the `.pyx`. Cython is already in `build-system.requires`, so every build frontend (uv, pip, cibuildwheel, sdist consumers) has it available.
- **`rebuild.py` simplified** to a thin wrapper around `uv sync --reinstall-package hdiffpatch` plus an import smoke test. Its previous direct `cythonize.py` invocation also crashed in uv-managed venvs (no `setuptools` in Python 3.13 venvs).
- **Emoji output removed** from `rebuild.py` — `✅`/`❌` raise `UnicodeEncodeError` on cp1252 Windows consoles (finishing what 6a4f659 started).

## Verification

- Deleted `_c_extension.cpp` and ran plain `uv sync` → extension regenerated and built, 507 tests pass.
- `touch`ed the `.pyx` and ran `uv run python rebuild.py` → stale `.cpp` regenerated, rebuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
