### PR TITLE
Overhaul CI per python-template: trusted publishing, py3.14, native arm64

### DIFF
--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -3,50 +3,44 @@ name: Build Wheels
 on:
   workflow_dispatch:
   pull_request:
+    # Only build wheels on PRs when compiled code (or the build itself) changes.
+    paths:
+      - "**.pyx"
+      - "**.pxd"
+      - "hdiffpatch/_c_src/**"
+      - "setup.py"
+      - "cythonize.py"
+      - "pyproject.toml"
+      - ".github/workflows/build_wheels.yaml"
   push:
     tags:
       - "v*.*.*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build_sdist:
     name: "sdist"
     runs-on: ubuntu-latest
-    env:
-      PYTHON: 3.12
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Set up python ${{ env.PYTHON }}
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON }}
-
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Install build dependencies and cythonize
-        shell: bash
-        run: |
-          python -m venv .venv
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            source .venv/Scripts/activate
-          else
-            source .venv/bin/activate
-          fi
-          pip install "setuptools>=61.0" "setuptools-scm>=8.0" "Cython>=3.0.0"
-          python cythonize.py
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
 
       - name: Build sdist
-        run: |
-          uv build --sdist
+        run: uv build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-sdist
           path: dist/*.tar.gz
@@ -58,13 +52,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        cibw_build: ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
-        cibw_archs: ["AMD64", "x86", "ARM64"]
-        exclude:
-          - os: windows-latest
-            cibw_archs: "ARM64"
-    env:
-      PYTHON: 3.12
+        cibw_build: ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
+        cibw_archs: ["AMD64"]
 
     steps:
       - name: "Set environment variables (Windows)"
@@ -78,62 +67,37 @@ jobs:
         shell: bash
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Set up python ${{ env.PYTHON }}
-        uses: actions/setup-python@v5
-        id: setup-python
-        with:
-          python-version: ${{ env.PYTHON }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Install build dependencies and cythonize
-        shell: bash
-        run: |
-          python -m venv .venv
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            source .venv/Scripts/activate
-          else
-            source .venv/bin/activate
-          fi
-          pip install "setuptools>=61.0" "setuptools-scm>=8.0" "Cython>=3.0.0"
-          python cythonize.py
-
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v4.1
         env:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_BUILD: ${{ matrix.cibw_build }}
-          CIBW_PRERELEASE_PYTHONS: true
-          CIBW_TEST_SKIP: "*-win_arm64"
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}-${{ env.CIBW_BUILD_SANITIZED }}-${{ matrix.cibw_archs }}
           path: wheelhouse/*.whl
 
   build_wheels_linux:
-    name: "${{ matrix.os }} ${{ matrix.cibw_archs }} ${{ matrix.cibw_build }}"
+    name: "${{ matrix.os }} ${{ matrix.cibw_build }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        cibw_build: ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
-        cibw_archs: ["x86_64", "i686", "aarch64", "ppc64le"]
-    env:
-      PYTHON: 3.12
+        # ubuntu-24.04-arm builds aarch64 wheels natively (much faster than QEMU).
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        cibw_build: ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0
@@ -143,44 +107,16 @@ jobs:
         run: echo "CIBW_BUILD_SANITIZED=$(echo '${{ matrix.cibw_build }}' | sed 's/\*/_/g')" >> $GITHUB_ENV
         shell: bash
 
-      - name: Set up QEMU
-        if: matrix.cibw_archs != 'x86_64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
-      - name: Set up python ${{ env.PYTHON }}
-        uses: actions/setup-python@v5
-        id: setup-python
-        with:
-          python-version: ${{ env.PYTHON }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Install build dependencies and cythonize
-        shell: bash
-        run: |
-          python -m venv .venv
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            source .venv/Scripts/activate
-          else
-            source .venv/bin/activate
-          fi
-          pip install "setuptools>=61.0" "setuptools-scm>=8.0" "Cython>=3.0.0"
-          python cythonize.py
-
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v4.1
         env:
-          CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
-          name: wheels-${{ matrix.os }}-${{ env.CIBW_BUILD_SANITIZED }}-${{ matrix.cibw_archs }}
+          name: wheels-${{ matrix.os }}-${{ env.CIBW_BUILD_SANITIZED }}
           path: wheelhouse/*.whl
 
   build_wheels_macos:
@@ -189,15 +125,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13]
-        cibw_build: ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
-        cibw_archs: ["x86_64"]
-    env:
-      PYTHON: 3.12
-      SYSTEM_VERSION_COMPAT: 0 # https://github.com/actions/setup-python/issues/469#issuecomment-1192522949
+        os: [macos-latest]
+        cibw_build: ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
+        cibw_archs: ["arm64", "x86_64"]
+
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0
@@ -207,116 +141,20 @@ jobs:
         run: echo "CIBW_BUILD_SANITIZED=$(echo '${{ matrix.cibw_build }}' | sed 's/\*/_/g')" >> $GITHUB_ENV
         shell: bash
 
-      - name: Set up python ${{ env.PYTHON }}
-        uses: actions/setup-python@v5
-        id: setup-python
-        with:
-          python-version: ${{ env.PYTHON }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Install build dependencies and cythonize
-        shell: bash
-        run: |
-          python -m venv .venv
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            source .venv/Scripts/activate
-          else
-            source .venv/bin/activate
-          fi
-          pip install "setuptools>=61.0" "setuptools-scm>=8.0" "Cython>=3.0.0"
-          python cythonize.py
-
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v4.1
         env:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_BUILD: ${{ matrix.cibw_build }}
+          # x86_64 wheels are cross-compiled on arm64 runners; their tests can't run natively.
+          CIBW_TEST_SKIP: "*-macosx_x86_64"
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}-${{ env.CIBW_BUILD_SANITIZED }}-${{ matrix.cibw_archs }}
           path: wheelhouse/*.whl
-
-  build_wheels_macos_arm64:
-    name: "${{ matrix.os }} ${{ matrix.cibw_archs }} ${{ matrix.cibw_build }}"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-13]
-        cibw_build: ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
-        cibw_archs: ["arm64"]
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - name: Sanitize matrix.cibw_build
-        id: sanitize_build
-        run: echo "CIBW_BUILD_SANITIZED=$(echo '${{ matrix.cibw_build }}' | sed 's/\*/_/g')" >> $GITHUB_ENV
-        shell: bash
-
-      - uses: actions/setup-python@v5
-        id: setup-python
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Install build dependencies and cythonize
-        shell: bash
-        run: |
-          python -m venv .venv
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            source .venv/Scripts/activate
-          else
-            source .venv/bin/activate
-          fi
-          pip install "setuptools>=61.0" "setuptools-scm>=8.0" "Cython>=3.0.0"
-          python cythonize.py
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
-        env:
-          CIBW_BUILD: ${{ matrix.cibw_build }}
-          CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          CIBW_TEST_SKIP: "*-macosx_arm64"
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: pytest {package}/tests
-          CIBW_REPAIR_WHEEL_COMMAND: |
-            echo "Target delocate archs: {delocate_archs}"
-
-            ORIGINAL_WHEEL={wheel}
-
-            echo "Running delocate-listdeps to list linked original wheel dependencies"
-            delocate-listdeps --all $ORIGINAL_WHEEL
-
-            echo "Renaming .whl file when architecture is 'macosx_arm64'"
-            RENAMED_WHEEL=${ORIGINAL_WHEEL//x86_64/arm64}
-
-            echo "Wheel will be renamed to $RENAMED_WHEEL"
-            mv $ORIGINAL_WHEEL $RENAMED_WHEEL
-
-            echo "Running delocate-wheel command on $RENAMED_WHEEL"
-            delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v $RENAMED_WHEEL
-
-            echo "Running delocate-listdeps to list linked wheel dependencies"
-            WHEEL_SIMPLE_FILENAME="${RENAMED_WHEEL##*/}"
-            delocate-listdeps --all {dest_dir}/$WHEEL_SIMPLE_FILENAME
-
-            echo "DONE."
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: wheels-${{ matrix.os }}-${{ env.CIBW_BUILD_SANITIZED }}-${{ matrix.cibw_archs }}
-          path: ./wheelhouse/*.whl
 
   upload_to_pypi:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
@@ -326,14 +164,14 @@ jobs:
         "build_wheels_windows",
         "build_wheels_linux",
         "build_wheels_macos",
-        "build_wheels_macos_arm64",
       ]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      # Required for PyPI Trusted Publishing (OIDC); no API token needed.
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: wheels
           pattern: wheels-*
@@ -341,6 +179,5 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: wheels/
           skip-existing: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,6 @@
 # Regular tests
 #
-# Use this to ensure your tests are passing on every push and PR (skipped on
-# pushes which only affect documentation).
+# Use this to ensure your tests are passing on every push and PR.
 #
 # You should make sure you run jobs on at least the *oldest* and the *newest*
 # versions of python that your codebase is intended to support.
@@ -14,7 +13,39 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  # Lint doesn't depend on OS or python version; run it once.
+  lint:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Install library
+        run: uv sync --locked
+
+      - name: Cache pre-commit
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/pre-commit/
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Pre-commit run
+        run: uv run pre-commit run --show-diff-on-failure --color=always --all-files
+
   test:
     timeout-minutes: 45
     defaults:
@@ -24,66 +55,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - name: Set up python ${{ matrix.python-version }}
-        id: setup-python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Install build dependencies and cythonize
-        shell: bash
-        run: |
-          python -m venv .venv-build
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            source .venv-build/Scripts/activate
-          else
-            source .venv-build/bin/activate
-          fi
-          pip install "setuptools>=61.0" "setuptools-scm>=8.0" "Cython>=3.0.0"
-          python cythonize.py
-
-      - name: Install library and dependencies
-        run: uv sync
-
-      - name: Cache pre-commit
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit/
-          key: pre-commit-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: Pre-commit run
-        run: uv run pre-commit run --show-diff-on-failure --color=always --all-files
-
-      - name: Check tests folder existence
-        id: check_test_files
-        uses: andstor/file-existence-action@v3
-        with:
-          files: "tests"
+      - name: Install library
+        run: uv sync --locked
 
       - name: Run tests
-        if: steps.check_test_files.outputs.files_exists == 'true'
         run: |
           uv run python -m pytest --cov=hdiffpatch --cov-report term --cov-report xml --junitxml=testresults.xml
           uv run coverage report
 
       - name: Upload coverage to Codecov
-        if: steps.check_test_files.outputs.files_exists == 'true'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: C++",
     "Programming Language :: Cython",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
## Summary

Rewrites both workflows modeled on [BrianPugh/python-template](https://github.com/BrianPugh/python-template), including the migration to PyPI Trusted Publishing.

**Stacked on `fix/bootstrap`** — the removal of the "build a pip venv and run cythonize.py" block from every job relies on setup.py auto-cythonizing. Merge that PR first; this one then rebases to just the workflow changes.

## tests.yaml

- Single `lint` job runs pre-commit once, instead of on all 15 matrix jobs.
- Matrix adds **Python 3.14**; `macos-13` (x86_64, deprecated runner) → `macos-latest` (arm64), so tests now cover the most common mac target.
- Python is uv-managed via `setup-uv@v7` with caching; drops `actions/setup-python` and the manual build venv.
- `uv sync --locked`; concurrency groups cancel superseded PR runs.

## build_wheels.yaml

- cibuildwheel v2.23.3 → **v4.1**; adds **cp314 wheels** (v4 only dropped cp38, so cp39 remains).
- **aarch64 wheels build natively on `ubuntu-24.04-arm`** instead of QEMU (much faster).
- **macOS builds on `macos-latest` (arm64)**: arm64 wheels are now actually tested (they never were before — `CIBW_TEST_SKIP: "*-macosx_arm64"`); x86_64 becomes the cross-compiled, test-skipped arch. The manual delocate wheel-rename `CIBW_REPAIR_WHEEL_COMMAND` is gone.
- Dropped niche targets: linux i686/ppc64le (were QEMU-built) and windows x86. Shout if you still want any of these — easy to re-add.
- PR-triggered wheel builds now run only when compiled code or the build system changes (path filter), like the template.
- **Trusted Publishing only**: `pypa/gh-action-pypi-publish` with OIDC (`id-token: write`), `password: PYPI_TOKEN` removed. The `PYPI_TOKEN` secret can be deleted once the PyPI project has a trusted publisher configured for this repo/workflow/environment (`pypi`).

Also adds the `Programming Language :: Python :: 3.14` trove classifier.

## Verification

- `uv sync --locked --dry-run` resolves on both matrix endpoints (3.9 and 3.14).
- YAML lint (pre-commit check-yaml) passes.

## Post-merge checklist

- [ ] Configure the trusted publisher on PyPI (project `hdiffpatch`, workflow `build_wheels.yaml`, environment `pypi`)
- [ ] Delete the `PYPI_TOKEN` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)
