### PR TITLE
Update tamp to v2.3.0; expose opt-in extended format

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,9 @@ Fine-grained control over [Tamp](https://github.com/BrianPugh/tamp) compression 
 ```python
 config = hdiffpatch.TampConfig(window=10)
 
+# Tamp v2 extended format (better compression; requires a Tamp v2+ decoder)
+config = hdiffpatch.TampConfig(extended=True)
+
 # Preset configurations
 config = hdiffpatch.TampConfig.fast()
 config = hdiffpatch.TampConfig.balanced()
@@ -269,6 +272,7 @@ config = hdiffpatch.TampConfig.minimal_memory()
 **Parameters:**
 
 * `window` (8-15): Window size as power of 2
+* `extended` (bool, default `False`): Use the Tamp v2 extended format (run-length encoding, longer matches) for better compression. Off by default because the resulting diffs cannot be decompressed by Tamp v1.x decoders.
 
 ### Exceptions
 

--- a/hdiffpatch/_c_extension.pyx
+++ b/hdiffpatch/_c_extension.pyx
@@ -184,6 +184,7 @@ cdef extern from "tamp_compress_plugin.cpp":
         int             window         # 8..15
         int             literal        # 5..8 (fixed at 8)
         int             use_custom_dictionary  # 0 or 1
+        int             extended       # 0 or 1
 
 # TCompressPlugin_bz2 structure for custom bzip2 configuration
 cdef extern from "compress_plugin_demo.h":
@@ -394,6 +395,7 @@ cdef TCompressPlugin_tamp* create_custom_tamp_plugin(tamp_config) except NULL:
     custom_plugin.window = tamp_config.window
     custom_plugin.literal = 8  # Fixed at 8
     custom_plugin.use_custom_dictionary = 0
+    custom_plugin.extended = 1 if tamp_config.extended else 0
 
     return custom_plugin
 

--- a/hdiffpatch/_c_src/tamp_compress_plugin.cpp
+++ b/hdiffpatch/_c_src/tamp_compress_plugin.cpp
@@ -19,6 +19,7 @@ typedef struct {
     int             window;         // 8..15
     int             literal;        // 5..8 (fixed at 8)
     int             use_custom_dictionary;  // 0 or 1
+    int             extended;       // 0 or 1; Tamp v2 extended format (RLE, long matches)
 } TCompressPlugin_tamp;
 
 // Tamp compression function
@@ -34,11 +35,12 @@ static hpatch_StreamPos_t _tamp_compress(const hdiff_TCompress* compressPlugin,
 
     // Get configuration from custom plugin or use defaults
     const TCompressPlugin_tamp* tamp_plugin = (const TCompressPlugin_tamp*)compressPlugin;
-    TampConf conf = {
-        static_cast<uint16_t>(tamp_plugin->window),
-        static_cast<uint16_t>(tamp_plugin->literal),
-        static_cast<uint16_t>(tamp_plugin->use_custom_dictionary)
-    };
+    TampConf conf;
+    memset(&conf, 0, sizeof(conf));  // extended=0 keeps output v1-compatible unless requested
+    conf.window = static_cast<uint16_t>(tamp_plugin->window);
+    conf.literal = static_cast<uint16_t>(tamp_plugin->literal);
+    conf.use_custom_dictionary = static_cast<uint16_t>(tamp_plugin->use_custom_dictionary);
+    conf.extended = static_cast<uint16_t>(tamp_plugin->extended);
 
     // Validate that custom dictionary is not used (not yet supported)
     if (conf.use_custom_dictionary) {
@@ -121,7 +123,8 @@ static const TCompressPlugin_tamp tampCompressPlugin = {
     {_tamp_compressType, _default_maxCompressedSize, _default_setParallelThreadNumber, _tamp_compress},
     10,  // window
     8,   // literal
-    0    // use_custom_dictionary
+    0,   // use_custom_dictionary
+    0    // extended
 };
 
 //=============================================================================
@@ -158,22 +161,23 @@ static hpatch_decompressHandle _tamp_decompress_open(hpatch_TDecompress* decompr
     _tamp_TDecompress* self = 0;
     TampConf conf;
     tamp_res res;
-    unsigned char header_buf[1];
+    unsigned char header_buf[2];
+    size_t header_avail = 0;
     size_t header_consumed = 0;
 
-    // Verify we have at least the header byte
+    // Verify we have at least the first header byte; read up to 2 (v2 streams
+    // with the more_header bit set have a second header byte)
     if (code_end - code_begin < 1) {
         return NULL;
     }
-
-    // Read the 1-byte header to determine window size
-    if (!codeStream->read(codeStream, code_begin, header_buf, header_buf + 1)) {
+    header_avail = (code_end - code_begin >= 2) ? 2 : 1;
+    if (!codeStream->read(codeStream, code_begin, header_buf, header_buf + header_avail)) {
         return NULL;
     }
 
     // Parse header to get configuration
-    res = tamp_decompressor_read_header(&conf, header_buf, 1, &header_consumed);
-    if (res != TAMP_OK || header_consumed != 1) {
+    res = tamp_decompressor_read_header(&conf, header_buf, header_avail, &header_consumed);
+    if (res != TAMP_OK || header_consumed < 1 || header_consumed > header_avail) {
         return NULL;
     }
 
@@ -201,12 +205,12 @@ static hpatch_decompressHandle _tamp_decompress_open(hpatch_TDecompress* decompr
     self->input_buf_pos = 0;
     self->input_buf_avail = 0;
     self->codeStream = codeStream;
-    self->code_begin = code_begin + sizeof(header_buf); // Skip the header byte we already read
+    self->code_begin = code_begin + header_consumed; // Skip the header bytes we already read
     self->code_end = code_end;
     self->decError = hpatch_dec_ok;
 
     // Initialize Tamp decompressor with the parsed configuration
-    res = tamp_decompressor_init(&self->decompressor, &conf, self->window_buf);
+    res = tamp_decompressor_init(&self->decompressor, &conf, self->window_buf, (uint8_t)conf.window);
     if (res != TAMP_OK) {
         self->decError = hpatch_dec_error;
         return self;

--- a/hdiffpatch/_tamp_config.py
+++ b/hdiffpatch/_tamp_config.py
@@ -17,6 +17,11 @@ class TampConfig(BaseConfig):
     window : int, default=10
         Window size as power of 2 (8-15). Larger windows give
         better compression but use more memory. (1KB window)
+    extended : bool, default=False
+        Use the Tamp v2 extended format (run-length encoding and longer
+        matches) for better compression. Diffs produced with this enabled
+        cannot be applied by Tamp v1.x decompressors, so it is disabled
+        by default for backwards compatibility.
 
     Examples
     --------
@@ -27,6 +32,10 @@ class TampConfig(BaseConfig):
     Custom window size
 
     >>> config = TampConfig(window=12)
+
+    Extended format for better compression
+
+    >>> config = TampConfig(extended=True)
     """
 
     window: int = attrs.field(
@@ -36,6 +45,10 @@ class TampConfig(BaseConfig):
             attrs.validators.ge(8),
             attrs.validators.le(15),
         ),
+    )
+    extended: bool = attrs.field(
+        default=False,
+        validator=attrs.validators.instance_of(bool),
     )
 
     @classmethod

--- a/tests/test_tamp_config.py
+++ b/tests/test_tamp_config.py
@@ -13,11 +13,13 @@ class TestTampConfigClass:
         """Test default TampConfig construction."""
         config = TampConfig()
         assert config.window == 10
+        assert config.extended is False
 
     def test_custom_construction(self):
         """Test TampConfig construction with custom parameters."""
-        config = TampConfig(window=12)
+        config = TampConfig(window=12, extended=True)
         assert config.window == 12
+        assert config.extended is True
 
 
 class TestTampConfigValidation:
@@ -40,6 +42,12 @@ class TestTampConfigValidation:
         """Test window rejects invalid types."""
         with pytest.raises(TypeError, match="'window' must be <class 'int'>"):
             TampConfig(window=window)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("extended", ["yes", 1, None])
+    def test_extended_invalid_type(self, extended):
+        """Test extended rejects invalid types."""
+        with pytest.raises(TypeError, match="'extended' must be <class 'bool'>"):
+            TampConfig(extended=extended)  # type: ignore[arg-type]
 
 
 class TestTampConfigClassmethods:
@@ -203,6 +211,33 @@ class TestTampConfigRoundTrip:
         # Test round-trip
         result = hdiffpatch.apply(unicode_data["old"], diff_data)
         assert result == unicode_data["new"]
+
+    @pytest.mark.parametrize("window", [8, 10, 12, 15])
+    def test_round_trip_extended_all_windows(self, unicode_data, window):
+        """Test round-trip with the extended format across window sizes."""
+        config = TampConfig(window=window, extended=True)
+
+        diff_data = hdiffpatch.diff(unicode_data["old"], unicode_data["new"], compression=config)
+
+        assert isinstance(diff_data, bytes)
+        assert len(diff_data) > 0
+
+        result = hdiffpatch.apply(unicode_data["old"], diff_data)
+        assert result == unicode_data["new"]
+
+    def test_extended_differs_from_default(self, large_repetitive_data):
+        """Test that the extended format produces a different (v2) stream than the default."""
+        diff_default = hdiffpatch.diff(
+            large_repetitive_data["old"], large_repetitive_data["new"], compression=TampConfig()
+        )
+        diff_extended = hdiffpatch.diff(
+            large_repetitive_data["old"], large_repetitive_data["new"], compression=TampConfig(extended=True)
+        )
+
+        assert diff_default != diff_extended
+
+        result = hdiffpatch.apply(large_repetitive_data["old"], diff_extended)
+        assert result == large_repetitive_data["new"]
 
     @pytest.mark.parametrize(
         "config_method",


### PR DESCRIPTION
## Summary

Bumps the tamp submodule from v1.7.0-10 to v2.3.0 and adapts the compression plugin to the v2 API.

- `tamp_decompressor_init` now takes a `window_bits` argument; the plugin passes the window size parsed from the stream header.
- `TampConf` gained `extended`/`dictionary_reset`/`append` bitfields; the plugin zero-initializes them so default output stays in the v1 format.
- The tamp header can now be 1-2 bytes (`more_header` bit), so the decompressor plugin reads and skips a variable-length header instead of assuming exactly 1 byte.
- Exposes the v2 extended format (RLE + longer matches) as `TampConfig(extended=True)`. It is off by default because extended streams cannot be decoded by tamp v1.x decompressors.

## Backwards compatibility

Verified against a pre-update build (tamp v1.7/v1.8-era) in both directions: default diff output is byte-identical to the previous release, the old build applies new-build diffs and vice versa, and extended diffs fail with a clean `HDiffPatchError` on the old build rather than producing corrupt output.

## Testing

- Full test suite passes (500 tests), including new parametrized round-trip tests for `extended=True` across all window sizes.
- `pre-commit run --all-files` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)