### PR TITLE
Performance: zstd asm, LTO on Unix, release the GIL in diff/apply

### DIFF
--- a/hdiffpatch/_c_extension.pyx
+++ b/hdiffpatch/_c_extension.pyx
@@ -40,7 +40,7 @@ cdef extern from "libHDiffPatch/HDiff/diff.h":
     void hdiff_create_compressed_diff "create_compressed_diff"(const unsigned char* newData, const unsigned char* newData_end,
                                                              const unsigned char* oldData, const unsigned char* oldData_end,
                                                              vector[unsigned char]& out_diff,
-                                                             const hdiff_TCompress* compressPlugin)
+                                                             const hdiff_TCompress* compressPlugin) except + nogil
 
 cdef extern from "libHDiffPatch/HPatch/patch_types.h":
     ctypedef struct hpatch_TDecompress:
@@ -49,7 +49,7 @@ cdef extern from "libHDiffPatch/HPatch/patch_types.h":
 cdef extern from "libHDiffPatch/HPatch/patch.h":
     int patch(unsigned char* out_newData, unsigned char* out_newData_end,
              const unsigned char* oldData, const unsigned char* oldData_end,
-             const unsigned char* diff, const unsigned char* diff_end)
+             const unsigned char* diff, const unsigned char* diff_end) nogil
 
     hpatch_BOOL getCompressedDiffInfo_mem(hpatch_compressedDiffInfo* out_diffInfo,
                                          const unsigned char* compressedDiff,
@@ -58,7 +58,7 @@ cdef extern from "libHDiffPatch/HPatch/patch.h":
     hpatch_BOOL patch_decompress_mem(unsigned char* out_newData, unsigned char* out_newData_end,
                                      const unsigned char* oldData, const unsigned char* oldData_end,
                                      const unsigned char* compressedDiff, const unsigned char* compressedDiff_end,
-                                     hpatch_TDecompress* decompressPlugin)
+                                     hpatch_TDecompress* decompressPlugin) nogil
 
     ctypedef struct hpatch_TCover:
         hpatch_StreamPos_t oldPos
@@ -835,10 +835,13 @@ def diff(
 
     compression_plugin = _resolve_compression_to_plugin(compression)
 
-    if compression_plugin is None:  # No compression - use NULL plugin for HDIFF13& header format
-        hdiff_create_compressed_diff(new_ptr, new_end, old_ptr, old_end, diff_vector, <hdiff_TCompress*>0)
-    else:
-        hdiff_create_compressed_diff(new_ptr, new_end, old_ptr, old_end, diff_vector, compression_plugin.plugin)
+    # NULL plugin means no compression - HDIFF13& header format
+    cdef const hdiff_TCompress* compress_plugin_ptr = <hdiff_TCompress*>0
+    if compression_plugin is not None:
+        compress_plugin_ptr = compression_plugin.plugin
+
+    with nogil:
+        hdiff_create_compressed_diff(new_ptr, new_end, old_ptr, old_end, diff_vector, compress_plugin_ptr)
 
     diff_size = diff_vector.size()
     if diff_size == 0:
@@ -919,8 +922,9 @@ def apply(
 
             new_end = new_ptr + new_size
 
-            result = patch_decompress_mem(new_ptr, new_end, old_ptr, old_end,
-                                        diff_ptr, diff_end, <hpatch_TDecompress*>decompress_plugin)
+            with nogil:
+                result = patch_decompress_mem(new_ptr, new_end, old_ptr, old_end,
+                                              diff_ptr, diff_end, <hpatch_TDecompress*>decompress_plugin)
         else:
             # This is an uncompressed diff - calculate the new data size from covers
             new_size = calculate_new_data_size(diff_ptr, diff_end)
@@ -935,7 +939,8 @@ def apply(
                     raise MemoryError("Failed to allocate memory for patched data")
                 new_end = new_ptr + new_size
 
-            result = patch(new_ptr, new_end, old_ptr, old_end, diff_ptr, diff_end)
+            with nogil:
+                result = patch(new_ptr, new_end, old_ptr, old_end, diff_ptr, diff_end)
 
         if result == 0:
             raise HDiffPatchError("HDiffPatch patch operation failed")

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,10 @@ class CustomBuildExt(build_ext):
     """Custom build_ext to handle C++ standard flags for mixed C/C++ extensions."""
 
     def build_extension(self, ext):
+        # distutils' UnixCCompiler doesn't know .S (preprocessed assembly) by default
+        if ".S" not in self.compiler.src_extensions:
+            self.compiler.src_extensions.append(".S")
+
         # Override the _compile method to add C++ standard only for C++ files
         original_compile = self.compiler._compile
 
@@ -124,6 +128,10 @@ def get_sources():
     sources.extend((zstd_path / "common").glob("*.c"))
     sources.extend((zstd_path / "decompress").glob("*.c"))
     sources.extend((zstd_path / "compress").glob("*.c"))
+    # zstd's x86-64 BMI2 assembly decode path (runtime-dispatched, baseline-safe).
+    # MSVC cannot assemble it; on other architectures it preprocesses to nothing.
+    if platform.system() != "Windows" and platform.machine().lower() in ["x86_64", "amd64"]:
+        sources.append(zstd_path / "decompress" / "huf_decompress_amd64.S")
 
     # BZ2
     bz2_sources = ["blocksort.c", "bzlib.c", "compress.c", "crctable.c", "decompress.c", "huffman.c", "randtable.c"]
@@ -192,7 +200,6 @@ def get_compile_args():
         "-D_CompressPlugin_zstd",
         "-DZSTD_HAVE_WEAK_SYMBOLS=0",
         "-DZSTD_TRACE=0",
-        "-DZSTD_DISABLE_ASM=1",
         "-DZSTDLIB_VISIBLE=",
         "-DZSTDLIB_HIDDEN=",
         "-D_CompressPlugin_bz2",
@@ -207,6 +214,7 @@ def get_compile_args():
     if platform.system() == "Windows":
         extra_compile_args.extend(
             [
+                "-DZSTD_DISABLE_ASM=1",  # MSVC cannot assemble zstd's GAS-syntax .S file
                 "/O2",  # Maximum optimization for Windows
                 "/std:c++17",  # Use C++17 standard
                 "/D_CRT_SECURE_NO_WARNINGS",
@@ -236,6 +244,7 @@ def get_compile_args():
         # Add performance optimizations if enabled
         if enable_aggressive_opts:
             extra_compile_args.append("-funroll-loops")  # Unroll loops for better performance
+            extra_compile_args.append("-flto")  # Link-time optimization (matches /GL+/LTCG on Windows)
 
             # ISA extensions beyond the x86-64 baseline would SIGILL on older
             # CPUs, so only use them for local (non-redistributed) builds.
@@ -259,7 +268,9 @@ def get_link_args():
         if enable_aggressive_opts:
             extra_link_args.extend(["/LTCG"])  # Link-time code generation
     else:
-        extra_link_args.extend(["-O3"])  # Basic optimization without LTO
+        extra_link_args.extend(["-O3"])
+        if enable_aggressive_opts:
+            extra_link_args.append("-flto")  # Must match the compile-time flag
 
     return extra_link_args
 

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,0 +1,66 @@
+"""Tests for GIL release and thread-safety of diff/apply.
+
+diff() and apply() release the GIL around the core C/C++ calls, so
+concurrent calls from multiple threads must run correctly and actually
+overlap instead of serializing behind the GIL.
+"""
+
+import concurrent.futures
+import threading
+
+import pytest
+
+import hdiffpatch
+
+
+@pytest.fixture
+def firmware_like_data():
+    """Generate moderately large binary data pairs for concurrency tests."""
+    old = bytes(range(256)) * 400
+    new = old[:40000] + b"inserted section" * 64 + old[40000:] + b"\x00" * 1024
+    return {"old": old, "new": new}
+
+
+@pytest.mark.parametrize("compression", ["none", "zlib", "zstd", "tamp"])
+def test_concurrent_diff_correctness(firmware_like_data, compression):
+    """Test that concurrent diff() calls from many threads all round-trip."""
+    old = firmware_like_data["old"]
+    new = firmware_like_data["new"]
+
+    def worker(_):
+        diff_data = hdiffpatch.diff(old, new, compression=compression)
+        return hdiffpatch.apply(old, diff_data)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(worker, range(16)))
+
+    assert all(result == new for result in results)
+
+
+def test_diff_releases_gil():
+    """Test that another Python thread makes progress while diff() runs."""
+    # Large enough that the diff itself takes a macroscopic amount of time
+    old = bytes(range(256)) * 8192  # 2 MiB
+    new = old[: len(old) // 2] + b"wedge" * 1000 + old[len(old) // 2 :]
+
+    counter = 0
+    stop = threading.Event()
+
+    def count():
+        nonlocal counter
+        while not stop.is_set():
+            counter += 1
+
+    thread = threading.Thread(target=count)
+    thread.start()
+    try:
+        before = counter
+        hdiffpatch.diff(old, new, compression="lzma", validate=False)
+        during = counter - before
+    finally:
+        stop.set()
+        thread.join()
+
+    # With the GIL held for the whole C call, the counter thread is frozen for
+    # the duration of diff() (a single bytecode); released, it runs throughout.
+    assert during > 1000


### PR DESCRIPTION
## Summary

Stacked on #13 (targets its branch; GitHub will retarget to main when #13 merges). Three compile/runtime performance improvements:

- **zstd x86-64 assembly decode path enabled**: `ZSTD_DISABLE_ASM` is now only defined on Windows (MSVC cannot assemble the GAS-syntax file). On Unix x86-64 builds we compile `huf_decompress_amd64.S`, which upstream measures at ~15-20% faster zstd decompression. The asm dispatches on BMI2 at runtime, so baseline-ISA wheels stay safe on old CPUs; other architectures keep using the C fallback.
- **LTO on Unix**: `-flto` added to compile and link flags (gated on `HDIFFPATCH_AGGRESSIVE_OPTS=1` like the other perf flags). Windows already had `/GL` + `/LTCG`; this removes the asymmetry. If any wheel target chokes on it, the cibuildwheel matrix will surface it on this PR.
- **GIL released during `diff()` and `apply()`**: the core `create_compressed_diff` / `patch` / `patch_decompress_mem` calls now run in `nogil` blocks, so multi-second diffs no longer freeze other Python threads. The compression plugin callbacks are pure C/C++ and never touch Python state. As a bonus, `create_compressed_diff` now has `except +`, so a C++ exception raises `HDiffPatchError`-convertible Python errors instead of terminating the process. `recompress()` still holds the GIL because its output-stream callback casts through a Python object.

## Testing

- Full suite passes (516 tests) including new `tests/test_threading.py`: concurrent diff/apply correctness across compression types, and a counter-thread test asserting another thread makes progress while `diff()` runs.
- Local build (macOS arm64) exercises LTO; the x86-64 asm path is validated by the Linux/macOS x86-64 wheel builds in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)