### PR TITLE
Fix tamp compression failure on incompressible diff payloads

### DIFF
--- a/hdiffpatch/_c_src/tamp_compress_plugin.cpp
+++ b/hdiffpatch/_c_src/tamp_compress_plugin.cpp
@@ -76,29 +76,39 @@ static hpatch_StreamPos_t _tamp_compress(const hdiff_TCompress* compressPlugin,
         if (readLen > (size_t)(in_data->streamSize - readFromPos))
             readLen = (size_t)(in_data->streamSize - readFromPos);
 
-        // Read data from input
+        // Read the whole chunk exactly once. in_data is HDiffPatch's
+        // TNewDataDiffStream, which generates diff bytes on the fly and only
+        // supports strictly sequential reads, so we must never re-read or rewind.
         if (!in_data->read(in_data, readFromPos, read_buf, read_buf + readLen))
             _compress_error_return("in_data->read()");
 
-        // Compress the chunk
-        size_t output_written = 0;
-        size_t input_consumed = 0;
-        res = tamp_compressor_compress(&compressor, compress_buf, kCompressBufSize,
-                                       &output_written, read_buf, readLen, &input_consumed);
+        // Drain the chunk in place. tamp_compressor_compress legitimately
+        // consumes only part of its input when the output buffer fills
+        // (TAMP_OUTPUT_FULL), which happens whenever incompressible data expands
+        // under literal encoding. Advance an offset into read_buf until the whole
+        // chunk is consumed, flushing output after each call.
+        size_t chunk_pos = 0;
+        while (chunk_pos < readLen) {
+            size_t output_written = 0;
+            size_t input_consumed = 0;
+            res = tamp_compressor_compress(&compressor, compress_buf, kCompressBufSize,
+                                           &output_written, read_buf + chunk_pos,
+                                           readLen - chunk_pos, &input_consumed);
 
-        if (res < 0) _compress_error_return("tamp_compressor_compress");
+            if (res < 0) _compress_error_return("tamp_compressor_compress");
 
-        // Write compressed data
-        if (output_written > 0) {
-            _stream_out_code_write(out_code, outStream_isCanceled, result, compress_buf, output_written);
+            if (output_written > 0) {
+                _stream_out_code_write(out_code, outStream_isCanceled, result, compress_buf, output_written);
+            }
+
+            // Guard against a no-progress infinite loop.
+            if (input_consumed == 0 && output_written == 0)
+                _compress_error_return("tamp_compressor_compress made no progress");
+
+            chunk_pos += input_consumed;
         }
 
-        readFromPos += input_consumed;
-
-        // If we didn't consume all input, we need to handle partial consumption
-        if (input_consumed < readLen) {
-            readFromPos -= (readLen - input_consumed);
-        }
+        readFromPos += readLen;
     }
 
     // Flush any remaining data

--- a/tests/test_tamp_incompressible.py
+++ b/tests/test_tamp_incompressible.py
@@ -1,0 +1,24 @@
+"""Regression tests for tamp compression on incompressible diff payloads.
+
+High-entropy data expands under tamp's literal encoding (~1.125x), so a 32 KB
+input chunk cannot fit into a same-sized output buffer. This exercises the
+partial-consumption path of ``tamp_compressor_compress`` against HDiffPatch's
+sequential-only ``TNewDataDiffStream``.
+"""
+
+import random
+
+import pytest
+
+import hdiffpatch
+
+
+@pytest.mark.parametrize("window", [8, 10])
+def test_diff_apply_roundtrip_incompressible(window):
+    """Round-trip a large incompressible payload through tamp compression."""
+    rng = random.Random(42)  # noqa: S311
+    old = rng.randbytes(1_350_000)
+    new = rng.randbytes(1_350_000)
+
+    patch = hdiffpatch.diff(old, new, compression=hdiffpatch.TampConfig(window=window))
+    assert hdiffpatch.apply(old, patch) == new


### PR DESCRIPTION
`hdiffpatch.diff(old, new, compression="tamp")` failed with `RuntimeError: TNewDataDiffStream::read() readFromPos error!` whenever any 32 KB chunk of the diff payload was incompressible — for example high-entropy data, which expands by roughly 1.125x under tamp's 9-bits-per-byte literal encoding. On hdiffpatch 1.0.0 wheels this manifested as an uncatchable `std::terminate`/SIGABRT that killed the whole process (exception translation for the diff path is being hardened separately).

The root cause was in `_tamp_compress`'s chunk loop. `tamp_compressor_compress` legitimately consumes only part of its input when the output buffer fills (it returns `TAMP_OUTPUT_FULL`, a positive success code), and this happens whenever a chunk expands under compression because `compress_buf` is the same size as `read_buf` (both `kCompressBufSize` = 32 KB). On partial consumption the old code rewound `readFromPos` to re-read the unconsumed tail, and it rewound too far — a double correction, since `readFromPos += input_consumed` had already accounted for the partial consumption before the extra subtraction ran. Even a correctly computed rewind would have failed, because the input here is HDiffPatch's `TNewDataDiffStream`, which generates diff bytes on the fly and only supports strictly sequential reads; any non-sequential read throws `std::runtime_error`.

The fix restructures the loop so the stream is only ever read sequentially, one full chunk at a time: read a chunk of `readLen` bytes once, then drain it with an inner loop that advances an offset into `read_buf` by `input_consumed` and writes `output_written` bytes after each `tamp_compressor_compress` call, until the whole chunk is consumed. A no-progress guard fails cleanly if a call consumes no input and writes no output, and `readFromPos` only ever advances by the full chunk length — never decrements, never re-reads. The end-of-stream flush is unchanged, since `tamp_compressor_flush`'s worst-case output (23 bytes) is far smaller than the 32 KB output buffer.

The new `tests/test_tamp_incompressible.py` reproduces the bug deterministically: it round-trips two ~1.35 MB buffers of seeded-random bytes (`random.Random(42)`) through `diff`/`apply`, parametrized over window sizes 8 and 10. It fails against the old code with the `TNewDataDiffStream::read()` error and passes with the fix. The full suite (524 tests) and pre-commit both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
