### PR TITLE
Translate C++ core exceptions into HDiffPatchError instead of RuntimeError

### DIFF
--- a/hdiffpatch/_c_extension.pyx
+++ b/hdiffpatch/_c_extension.pyx
@@ -19,6 +19,47 @@ from libc.stddef cimport size_t
 from libcpp.vector cimport vector
 from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AsString, PyBytes_Size
 
+# C++ -> Python exception translator.
+#
+# The HDiffPatch C++ core throws ``std::runtime_error`` (and, on OOM,
+# ``std::bad_alloc``) from internal stream code. A bare ``except +`` would map
+# these onto Python's builtin ``RuntimeError``/``MemoryError``, but the package
+# contract is that every diff/patch/compression failure raises
+# ``HDiffPatchError``. ``except +hdiffpatch_translate_exception`` on the extern
+# C++ declarations below routes those throws through this handler instead:
+# ``std::bad_alloc`` stays a ``MemoryError`` (never swallow OOM), everything
+# else becomes ``HDiffPatchError`` carrying the original ``what()`` message.
+# Cython calls the handler from inside the generated ``catch (...)`` block with
+# the GIL held, so ``throw;`` re-raises the in-flight exception for inspection.
+cdef extern from *:
+    """
+    #include <exception>
+    #include <new>
+    #include <Python.h>
+
+    static PyObject* __hdiffpatch_error_type = NULL;
+
+    static void hdiffpatch_register_error(PyObject* error_type) {
+        __hdiffpatch_error_type = error_type;
+    }
+
+    static void hdiffpatch_translate_exception() {
+        PyObject* error_type =
+            __hdiffpatch_error_type ? __hdiffpatch_error_type : PyExc_RuntimeError;
+        try {
+            throw;
+        } catch (const std::bad_alloc& exn) {
+            PyErr_SetString(PyExc_MemoryError, exn.what());
+        } catch (const std::exception& exn) {
+            PyErr_SetString(error_type, exn.what());
+        } catch (...) {
+            PyErr_SetString(error_type, "Unknown C++ exception raised by HDiffPatch");
+        }
+    }
+    """
+    void hdiffpatch_register_error(object error_type)
+    void hdiffpatch_translate_exception()
+
 cdef extern from "libHDiffPatch/HPatch/patch_types.h":
     ctypedef unsigned long long hpatch_StreamPos_t
     ctypedef int hpatch_BOOL
@@ -40,7 +81,7 @@ cdef extern from "libHDiffPatch/HDiff/diff.h":
     void hdiff_create_compressed_diff "create_compressed_diff"(const unsigned char* newData, const unsigned char* newData_end,
                                                              const unsigned char* oldData, const unsigned char* oldData_end,
                                                              vector[unsigned char]& out_diff,
-                                                             const hdiff_TCompress* compressPlugin) except + nogil
+                                                             const hdiff_TCompress* compressPlugin) except +hdiffpatch_translate_exception nogil
 
 cdef extern from "libHDiffPatch/HPatch/patch_types.h":
     ctypedef struct hpatch_TDecompress:
@@ -113,7 +154,7 @@ cdef extern from "libHDiffPatch/HDiff/diff.h":
                                hpatch_TDecompress* decompressPlugin,
                                const hpatch_TStreamOutput* out_diff,
                                const hdiff_TCompress* compressPlugin,
-                               hpatch_StreamPos_t out_diff_curPos) except +
+                               hpatch_StreamPos_t out_diff_curPos) except +hdiffpatch_translate_exception
 
     hpatch_StreamPos_t resave_single_compressed_diff(
         const hpatch_TStreamInput* in_diff,
@@ -122,7 +163,7 @@ cdef extern from "libHDiffPatch/HDiff/diff.h":
         const hdiff_TCompress* compressPlugin,
         const hpatch_singleCompressedDiffInfo* diffInfo,
         hpatch_StreamPos_t in_diff_curPos,
-        hpatch_StreamPos_t out_diff_curPos) except +
+        hpatch_StreamPos_t out_diff_curPos) except +hdiffpatch_translate_exception
 
 cdef extern from "compress_plugin_demo.h":
     extern const void* zlibCompressPlugin
@@ -219,6 +260,12 @@ _valid_compression_types = {"none", "zlib", "lzma", "lzma2", "zstd", "bzip2", "t
 
 class HDiffPatchError(Exception):
     """Base exception for HDiffPatch operations."""
+
+
+# Hand the exception type to the C++ translator so C++ throws from the core
+# surface as HDiffPatchError. The translator holds a borrowed reference; the
+# class lives for the lifetime of the module, so no incref is required.
+hdiffpatch_register_error(HDiffPatchError)
 
 
 cdef const hdiff_TCompress* get_compress_plugin(str compression):

--- a/tests/test_error_translation.py
+++ b/tests/test_error_translation.py
@@ -1,0 +1,30 @@
+"""Tests that C++ exceptions from the HDiffPatch core surface as HDiffPatchError."""
+
+import random
+
+import hdiffpatch
+
+
+def test_cpp_exceptions_surface_as_hdiffpatch_error():
+    """A C++ throw from the core must never escape as a bare RuntimeError.
+
+    Diffing two large seeded-random buffers with tamp compression currently
+    triggers a ``std::runtime_error`` inside the HDiffPatch C++ core. Cython's
+    bare ``except +`` would translate that into a builtin ``RuntimeError``,
+    violating the package contract that all diff/patch/compression failures
+    raise ``HDiffPatchError``.
+
+    This test is written to pass in both worlds: if the underlying tamp bug is
+    later fixed and the diff succeeds, the round-trip must validate; otherwise
+    the only acceptable failure is ``HDiffPatchError``. Any other exception
+    (notably a bare ``RuntimeError``) escaping is a failure.
+    """
+    rng = random.Random(42)  # noqa: S311
+    old = rng.randbytes(1_350_000)
+    new = rng.randbytes(1_350_000)
+    try:
+        patch = hdiffpatch.diff(old, new, compression=hdiffpatch.TampConfig(window=10))
+    except hdiffpatch.HDiffPatchError:
+        pass  # translated C++ error: acceptable
+    else:
+        assert hdiffpatch.apply(old, patch) == new


### PR DESCRIPTION
The HDiffPatch C++ core throws `std::runtime_error` on internal failures (for example `TNewDataDiffStream::read() readFromPos error!` from `stream_serialize.cpp`). In the released v1.0.0 the throwing extern declarations had no `except +` at all, so an in-flight C++ exception escaped Cython entirely and hit `std::terminate`, aborting the whole process with SIGABRT — which is how this class of bug was originally discovered. A later change added a bare `except +`, which stops the process from aborting but translates the C++ exception into Python's builtin `RuntimeError`. That still violates the package's documented contract (README, docstrings, CLAUDE.md): every diff/patch/compression failure is supposed to raise `hdiffpatch.HDiffPatchError`, and callers that catch `HDiffPatchError` were still seeing a bare `RuntimeError` slip past them.

This PR installs a custom Cython C++ exception translator (`except +hdiffpatch_translate_exception`) on the three throwing extern C++ functions — `create_compressed_diff`, `resave_compressed_diff`, and `resave_single_compressed_diff`. The translator re-raises the in-flight C++ exception from inside Cython's generated `catch` block and inspects it: `std::bad_alloc` still becomes Python `MemoryError` (we never swallow OOM into a generic error), and every other `std::exception` — plus any non-standard `...` throw — becomes `HDiffPatchError` carrying the original `what()` message. The `HDiffPatchError` type is defined in the same `.pyx`, so a module-level registration hands it to the translator at import time. It composes cleanly with the existing Python-level `try/except` in `apply`/`recompress`, which catch `HDiffPatchError` first, so there is no double-wrapping. I audited the remaining extern declarations: the patch-side functions are all `extern "C"` in `patch.h` and report failure via `hpatch_BOOL` return codes, so they cannot throw C++ exceptions and correctly need no translator; no undeclared-throw sites remain.

The new test in `tests/test_error_translation.py` triggers a real C++ throw (diffing two large seeded-random buffers with tamp compression). It is written to be forward-compatible with the independent tamp-plugin fix in #16 that removes this particular throw: it asserts that the call either succeeds (in which case the round-trip must validate) or raises `HDiffPatchError`, and it fails if any other exception — notably a bare `RuntimeError` — escapes. This test fails before the change (`RuntimeError: TNewDataDiffStream::read() readFromPos error!`) and passes after, the full suite (523 tests) passes, and pre-commit is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
